### PR TITLE
Changed qiskit.tools.outer to np.outer

### DIFF
--- a/qutomo/states.py
+++ b/qutomo/states.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 import qiskit
-from qiskit.tools import outer
+
 
 import methods
 import measurements
@@ -66,7 +66,7 @@ class State:
         Obtain density matrix by taking an outer product of state vector
         '''
         state_vector = self.get_state_vector()
-        state_matrix = outer(state_vector)
+        state_matrix = np.outer(state_vector, state_vector.T.conj())
         return state_matrix
     
     


### PR DESCRIPTION
Hi, I was very interested in benchmarking the code against one of my recent methods for quantum state reconstruction: [https://github.com/quantshah/qst-cgan](https://github.com/quantshah/qst-cgan) as well as the accelerated-projected-gradient descent method in [https://github.com/qMLE/qMLE](https://github.com/qMLE/qMLE). 

Thanks for the very nice implementation. While trying to reproduce the code I faced a few minor hiccups and I will be making PRs to address them. The most basic was the change in the definition of outer as recommended in a deprecation warning in the notebook. I replaced the qiskit.tools.outer to np.outer.

Thanks. 